### PR TITLE
Fix Veracruz CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ anyhow = "1.0.19"
 target-lexicon = { version = "0.11.0", default-features = false }
 pretty_env_logger = "0.4.0"
 file-per-thread-logger = "0.1.1"
-wat = "1.0.23"
+wat = "=1.0.37"
 libc = "0.2.60"
 log = "0.4.8"
 rayon = "1.2.1"


### PR DESCRIPTION
The Veracruz build environment can't build `wast` anymore since its bump to v36.0.0. That specific version of `wast` is a dependency of `wat v1.0.38`, which is a dependency of `wasmtime v0.20.0 (https://github.com/veracruz-project/wasmtime.git?branch=veracruz#c50c6368)`, which is a depency of `execution-engine v0.3.0`.
This PR fixes that by fixing the version of `wat` to v1.0.37, which depends on `wast` v35.*.