### PR TITLE
Fix all imports of Wat library to 1.0.37

### DIFF
--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -33,7 +33,7 @@ filecheck = "0.5.0"
 log = "0.4.8"
 term = "0.6.1"
 capstone = { version = "0.6.0", optional = true }
-wat = { version = "1.0.18", optional = true }
+wat = { version = "=1.0.37", optional = true }
 target-lexicon = { version = "0.11", features = ["std"] }
 peepmatic-souper = { path = "./peepmatic/crates/souper", version = "0.67.0", optional = true }
 pretty_env_logger = "0.4.0"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 thiserror = "1.0.4"
 
 [dev-dependencies]
-wat = "1.0.23"
+wat = "=1.0.37"
 target-lexicon = "0.11"
 # Enable the riscv feature for cranelift-codegen, as some tests require it
 cranelift-codegen = { path = "../codegen", version = "0.67.0", default-features = false, features = ["riscv"] }

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -24,7 +24,7 @@ wasmtime = { path = "../wasmtime", default-features = false }
 wasmtime-c-api-macros = { path = "macros" }
 
 # Optional dependency for the `wat2wasm` API
-wat = { version = "1.0.23", optional = true }
+wat = { version = "=1.0.37", optional = true }
 
 # Optional dependencies for the `wasi` feature
 wasi-common = { path = "../wasi-common", optional = true }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -19,4 +19,4 @@ wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
 
 [dev-dependencies]
-wat = "1.0.23"
+wat = "=1.0.37"

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -28,7 +28,7 @@ wasmparser = "0.59.0"
 
 [dev-dependencies]
 lazy_static = "1.2"
-wat = "1.0.23"
+wat = "=1.0.37"
 quickcheck = "0.9.0"
 anyhow = "1.0"
 

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -18,7 +18,7 @@ pretty_env_logger = "0.4.0"
 tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
-wat = "1.0.23"
+wat = "=1.0.37"
 
 [features]
 test_programs = []

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -25,7 +25,7 @@ backtrace = "0.3.42"
 rustc-demangle = "0.1.16"
 lazy_static = "1.4"
 log = "0.4.8"
-wat = { version = "1.0.18", optional = true }
+wat = { version = "=1.0.37", optional = true }
 smallvec = "1.4.0"
 serde = { version = "1.0.94", features = ["derive"] }
 bincode = "1.2.1"


### PR DESCRIPTION
Fix all version of the Wat library to version 1.0.37 to avoid problems when building `wasmtime` on our pinned compiler version.