### PR TITLE
wasmtime actually depends on bincode 1.3.x

### DIFF
--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -33,7 +33,7 @@ log = "0.4.8"
 wat = { version = "=1.0.37", optional = true }
 smallvec = "1.6.1"
 serde = { version = "1.0.94", features = ["derive"] }
-bincode = "1.2.1"
+bincode = "1.3"
 indexmap = "1.6"
 paste = "1.0.3"
 psm = "0.1.11"


### PR DESCRIPTION
[`wasmtime`](https://github.com/veracruz-project/wasmtime/blob/veracruz/crates/wasmtime/src/module/serialization.rs#L5) in `veracruz` branch contains:

```
use bincode::Options;
```

This variable `Options` is exported in bincode v1.3.0 [see](https://github.com/bincode-org/bincode/blob/v1.3.0/src/lib.rs#L45) but not in  bincode v1.2.1 [see](https://github.com/bincode-org/bincode/blob/v1.2.1/src/lib.rs#L41) and it does not export `Options` otherwise.