### PR TITLE
Remove #![feature(weak_into_raw)] and #![feature(array_value_iter)].

### DIFF
--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -275,8 +275,6 @@
 #![doc(test(attr(allow(dead_code, unused_variables, unused_mut))))]
 #![cfg_attr(nightlydoc, feature(doc_cfg))]
 #![cfg_attr(not(feature = "default"), allow(dead_code, unused_imports))]
-#![feature(weak_into_raw)]
-#![feature(array_value_iter)]
 
 #[macro_use]
 mod func;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,6 @@
         clippy::use_self
     )
 )]
-#![feature(weak_into_raw)]
-#![feature(array_value_iter)]
 
 const SUPPORTED_WASM_FEATURES: &[(&str, &str)] = &[
     ("all", "enables all supported WebAssembly features"),


### PR DESCRIPTION
I do not know what these are good for, but they prevent use of a
stable toolchain and removing them did not seem to break anything.