### PR TITLE
Remove #![feature(weak_into_raw)] and #![feature(array_value_iter)].

### DIFF
--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -275,8 +275,6 @@
 #![doc(test(attr(allow(dead_code, unused_variables, unused_mut))))]
 #![cfg_attr(nightlydoc, feature(doc_cfg))]
 #![cfg_attr(not(feature = "default"), allow(dead_code, unused_imports))]
-#![feature(weak_into_raw)]
-#![feature(array_value_iter)]
 
 #[macro_use]
 mod func;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,6 @@
         clippy::use_self
     )
 )]
-#![feature(weak_into_raw)]
-#![feature(array_value_iter)]
 
 const SUPPORTED_WASM_FEATURES: &[(&str, &str)] = &[
     ("all", "enables all supported WebAssembly features"),


### PR DESCRIPTION
Feature weak_into_raw has been stable since 1.45.0 (2020-07-16).
Feature array_value_iter has been stable since 1.51.0 (2021-03-25).

This PR should be merged immediately before https://github.com/veracruz-project/veracruz/pull/312,
and no earlier, because it would break the CI with `nightly-2020-05-07`.